### PR TITLE
Fix draw order

### DIFF
--- a/src/Assemble.Desktop/Components/TileRenderLayer.cs
+++ b/src/Assemble.Desktop/Components/TileRenderLayer.cs
@@ -1,0 +1,13 @@
+using Assemble.Desktop.Enums;
+
+namespace Assemble.Desktop.Components
+{
+    public class TileRenderLayer
+    {
+        public TileRenderLayerType Layer { get; }
+        public TileRenderLayer(TileRenderLayerType layer)
+        {
+            Layer = layer;
+        }
+    }
+}

--- a/src/Assemble.Desktop/DepthHelper.cs
+++ b/src/Assemble.Desktop/DepthHelper.cs
@@ -1,0 +1,18 @@
+using Assemble.Desktop.Components;
+
+namespace Assemble.Desktop
+{
+    public class DepthHelper
+    {
+        private float _heightModifier;
+        public DepthHelper((int x, int y) mapSize)
+        {
+            _heightModifier = 1.0f / (mapSize.x + mapSize.y);
+        }
+
+        public float GetDepth(TilePosition tilePosition)
+        {
+            return (tilePosition.Position.X + tilePosition.TileSpan.X + tilePosition.Position.Y + tilePosition.TileSpan.Y) * _heightModifier;
+        }
+    }
+}

--- a/src/Assemble.Desktop/EntityBuilder.cs
+++ b/src/Assemble.Desktop/EntityBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using Assemble.Desktop.Components;
+using Assemble.Desktop.Enums;
 using Assemble.Desktop.Extensions;
 using Microsoft.Xna.Framework;
 using MonoGame.Extended;
@@ -20,6 +21,7 @@ namespace Assemble.Desktop
         {
             entity.Attach(new TilePosition(tileIndex));
             entity.Attach(new Sprite(_texturesManager.GetTexture(Texture.Tile1, Texture.Tile2, Texture.Tile3, Texture.Tile4)));
+            entity.Attach(new TileRenderLayer(TileRenderLayerType.GroundTile));
             entity.Attach(new MapTile(Color.DarkGreen));
             return entity;
         }
@@ -38,6 +40,7 @@ namespace Assemble.Desktop
         {
             entity.Attach(new TilePosition(tileIndex));
             entity.Attach(new Sprite(_texturesManager.GetTexture(Texture.IronOre1, Texture.IronOre2, Texture.IronOre3)));
+            entity.Attach(new TileRenderLayer(TileRenderLayerType.Resources));
             entity.Attach(new MapTile(Color.LightBlue));
             return entity;
         }
@@ -47,6 +50,7 @@ namespace Assemble.Desktop
             entity.Attach(new TilePosition(tileIndex, tileSpan));
             entity.Attach(new Sprite(_texturesManager.GetTexture(Texture.Miner)) { Alpha = 0.7f });
             entity.Attach(new TileBorder() { Color = Color.LimeGreen });
+            entity.Attach(new TileRenderLayer(TileRenderLayerType.Overlay));
             entity.Attach(new Placeable());
             return entity;
         }
@@ -56,6 +60,7 @@ namespace Assemble.Desktop
             entity.Attach(new TilePosition(tileIndex, (2, 2)));
             entity.Attach(new Sprite(_texturesManager.GetTexture(Texture.Miner)));
             entity.Attach(new MapTile(Color.DarkBlue));
+            entity.Attach(new TileRenderLayer(TileRenderLayerType.Units));
             entity.Attach(new Unit());
             return entity;
         }

--- a/src/Assemble.Desktop/Enums/TileRenderLayerType.cs
+++ b/src/Assemble.Desktop/Enums/TileRenderLayerType.cs
@@ -1,0 +1,10 @@
+﻿namespace Assemble.Desktop.Enums
+{
+    public enum TileRenderLayerType
+    {
+        GroundTile,
+        Resources,
+        Units,
+        Overlay
+    }
+}

--- a/src/Assemble.Desktop/GameMain.cs
+++ b/src/Assemble.Desktop/GameMain.cs
@@ -43,7 +43,7 @@ namespace Assemble.Desktop
                 .AddSystem(new CameraSystem())
                 .AddSystem(new UnitGridOccupationSystem(gridManager))
                 .AddSystem(new ItemPlacementSystem(entityBuilder, _camera, gridManager))
-                .AddSystem(new RenderSystem(_spriteBatch, _camera))
+                .AddSystem(new TileRenderSystem(_spriteBatch, _camera, new DepthHelper((mapSize, mapSize))))
                 .AddSystem(new MapRenderSystem(_spriteBatch, _camera, mapSize))
                 .Build();
 


### PR DESCRIPTION
Allow for rendering tile things in layers. Also draw things in the correct order within each layer based on their isometric position.